### PR TITLE
helm-charts/ray-cluster: Allow multiple workers

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -47,6 +47,113 @@ spec:
 {{ include "ray-cluster.labels" . | indent 10 }}
 
   workerGroupSpecs:
+  {{- range $groupName, $values := .Values.extraWorkers }}
+  {{- if ne $values.disabled "true" }}
+  - groupName: {{ $groupName | quote }}
+    replicas: {{ $values.replicas }}
+    minReplicas: {{ $values.minReplicas | default 1 }}
+    maxReplicas: {{ $values.maxReplicas | default 2147483647 }}
+    {{- if $values.rayStartParams }}
+    rayStartParams:
+    {{- range $key, $val := $values.rayStartParams }}
+      {{ $key }}: {{ $val | quote }}
+    {{- end }}
+    {{- end }}
+    template:
+      metadata:
+        labels:
+          rayNodeType: {{ $values.type }}
+          groupName: {{ $groupName }}
+          rayCluster: {{ include "ray-cluster.fullname" $ }}
+{{ include "ray-cluster.labels" $ | indent 10 }}
+          {{- range $key, $val := $values.labels }}
+          {{ $key }}: {{ $val | quote }}
+          {{- end }}
+        {{- if $values.annotations }}
+        annotations:
+        {{- range $key, $val := $values.annotations }}
+          {{ $key }}: {{ $val | quote }}
+        {{- end }}
+        {{- end }}
+      spec:
+        {{- if $values.nodeSelector }}
+        nodeSelector:
+        {{- toYaml $values.nodeSelector | nindent 10 }}
+        {{- end }}
+        {{- if $values.tolerations }}
+        tolerations:
+        {{- toYaml $values.tolerations | nindent 10 }}
+        {{- end }}
+        {{- if $values.affinity }}
+        affinity: {{- toYaml $values.affinity | nindent 10 }}
+        {{- end }}
+        {{- if $values.initContainers }}
+        initContainers:
+        {{- range $key, $val := $values.initContainers }}
+        - name: {{ $key }}
+          image: {{ $val.image }}
+          command:
+          {{- range $k, $v := $val.command }}
+          - {{ $v }}
+          {{- end }}
+        {{- end }}
+        {{- end }}
+        containers:
+        - name: {{ $groupName }}
+          image: {{ $.Values.image.repository }}:{{ $.Values.image.tag }}
+          imagePullPolicy: {{ $.Values.image.pullPolicy }}
+          {{- if $values.args }}
+          args:
+          {{- range $key, $val := $values.args }}
+          - {{ $val }}
+          {{- end }}
+          {{- end }}
+          {{- if $values.command }}
+          command:
+          {{- range $key, $val := $values.command }}
+          - {{ $val }}
+          {{- end }}
+          {{- end }}
+          {{- if or $values.containerDefaultEnv $values.containerExtraEnv }}
+          env:
+          {{- if $values.containerDefaultEnv }}
+          {{- toYaml $values.containerDefaultEnv | nindent 10}}
+          {{- end }}
+          {{- if $values.containerExtraEnv }}
+          {{- toYaml $values.containerExtraEnv | nindent 10}}
+          {{- end }}
+          {{- end }}
+          {{- if $values.ports }}
+          ports:
+          {{- range $key, $val := $values.ports }}
+          - containerPort: {{ $val }}
+            name: {{ $key | quote }}
+          {{- end }}
+          {{- end }}
+          {{- if $values.lifecycle }}
+          lifecycle:
+          {{- toYaml $values.lifecycle | nindent 12 }}
+          {{- end }}
+          {{- if $values.resources }}
+          resources:
+            {{- if $values.resources.limits }}
+            limits:
+            {{- toYaml $values.resources.limits | nindent 14 }}
+            {{- end }}
+            {{- if $values.resources.requests }}
+            requests:
+            {{- toYaml $values.resources.requests | nindent 14 }}
+            {{- end }}
+          {{- end }}
+          {{- if $values.volumeMounts }}
+          volumeMounts: {{- toYaml $values.volumeMounts | nindent 12 }}
+          {{- end }}
+        {{- if $values.volumes }}
+        volumes: {{- toYaml $values.volumes | nindent 10 }}
+        {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- if ne .Values.worker.disabled "true" }}
   - rayStartParams:
     {{- range $key, $val := .Values.worker.initArgs }}
       {{ $key }}: {{ $val | quote }}
@@ -87,3 +194,4 @@ spec:
           groupName: {{ .Values.worker.groupName }}
           rayCluster: {{ include "ray-cluster.fullname" . }}
 {{ include "ray-cluster.labels" . | indent 10 }}
+  {{- end }}

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -52,6 +52,8 @@ head:
 
 
 worker:
+  ## If you want to disable the default worker group
+  # disabled: true
   groupName: workergroup
   replicas: 1
   type: worker
@@ -99,6 +101,82 @@ worker:
   volumeMounts:
     - mountPath: /tmp/ray
       name: log-volume
+
+extraWorkers:
+  generic:
+    disabled: true
+    type: worker
+    annotations: {}
+    labels: {}
+    rayStartParams:
+      redis-password: 'LetMeInRay'
+      node-ip-address: $MY_POD_IP
+      block: 'true'
+    replicas: 1
+    minReplicas: 1
+    maxReplicas: 3 # sane default for testing ray cluster
+    containerExtraEnv: {}
+    containerDefaultEnv:
+    - name: CPU_REQUEST
+      valueFrom:
+        resourceFieldRef:
+          containerName: generic
+          resource: requests.cpu
+    - name: CPU_LIMITS
+      valueFrom:
+        resourceFieldRef:
+          containerName: generic
+          resource: limits.cpu
+    - name: MEMORY_LIMITS
+      valueFrom:
+        resourceFieldRef:
+          containerName: generic
+          resource: limits.memory
+    - name: MEMORY_REQUESTS
+      valueFrom:
+        resourceFieldRef:
+          containerName: generic
+          resource: requests.memory
+    - name: MY_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: MY_POD_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    - name:  RAY_DISABLE_DOCKER_CPU_WARNING
+      value: "1"
+    - name: TYPE
+      value: "worker"
+    ports:
+      http: 80
+    resources:
+      limits:
+        cpu: "1"
+      requests:
+        cpu: "200m"
+    initContainers:
+      init-generic:
+        image: busybox:1.28
+        command:
+        - 'sh'
+        - '-c'
+        - "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for generic; sleep 2; done"
+    lifecycle:
+      preStop:
+        exec:
+          command: ["/bin/sh","-c","ray stop"]
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+    volumes:
+    - name: log-volume
+      emptyDir: {}
+    volumeMounts:
+    - mountPath: /tmp/ray
+      name: log-volume
+
 
 headServiceSuffix: "ray-operator.svc"
 


### PR DESCRIPTION
We can not set additional workers with the current helm chart.
There are some PRs that aim to fix this but they appear
to be stale https://github.com/ray-project/kuberay/pull/266

We wanted to keep untouched the default worker that is already
included in the helm chart but allow the addition of new workers.

The changes are adding the following logic:

 - Allow to disable the default worker group, if needed, via worker.disabled = true
 - Allow to set additional workers by using the extraWorkers map

The extraWorkers map has a different structure compared to the
default worker because I wanted to add additional flexibility.
Due to that, some variables in the extraWorkers have different
naming (which matches the name of the related CRD attributed)

Note: PR was done to support additional workers in the infrastructure of Metrika.co

Signed-off-by: Christos Kotsis <28815556+ulfox@users.noreply.github.com>
